### PR TITLE
Add .libsonnet filetype to auto-mode-alist

### DIFF
--- a/jsonnet-mode.el
+++ b/jsonnet-mode.el
@@ -235,6 +235,7 @@ If not inside of a multiline string, return nil."
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist (cons "\\.jsonnet\\'" 'jsonnet-mode))
+(add-to-list 'auto-mode-alist (cons "\\.libsonnet\\'" 'jsonnet-mode))
 
 ;; Utilities for evaluating and jumping around Jsonnet code.
 ;;;###autoload


### PR DESCRIPTION
## Description
Just added .libsonnet as a file extension match for jsonnet-mode.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project (see https://github.com/bbatsov/emacs-lisp-style-guide).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
