### PR TITLE
Accommodate library search directories during Jsonnet evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ definition of a given identifier.
 
 # Configuration
 
-There are two customizable parameters which you may configure in this mode:
+There are three customizable parameters that you may configure in this mode:
 
 - `jsonnet-command` allows you to indicate which Jsonnet binary should be used to render a JSON document.
+- `jsonnet-lib-dirs` specifies the sequence of Jsonnet library search directories use during evaluation.  
+  Relative paths in this sequence must resolve from the directory of the buffer being evaluated.
 - `jsonnet-enable-debug-print` will cause methods in jsonnet-mode to write messages to the status bar if enabled.

--- a/jsonnet-mode.el
+++ b/jsonnet-mode.el
@@ -46,6 +46,12 @@
   :type '(string)
   :group 'jsonnet)
 
+(defcustom jsonnet-lib-dirs
+  nil
+  "Sequence of Jsonnet library search directories, with later entries shadowing earlier entries."
+  :type '(repeat directory)
+  :group 'jsonnet)
+
 (defcustom jsonnet-enable-debug-print
   nil
   "If non-nil, enables debug printing in ‘jsonnet-mode’ functions."
@@ -249,7 +255,10 @@ If not inside of a multiline string, return nil."
         (save-buffer)))
     (with-current-buffer (get-buffer-create "*jsonnet output*")
       (erase-buffer)
-      (call-process jsonnet-command nil t nil buffer-to-eval)
+      (let ((args (cl-loop for dir in jsonnet-lib-dirs
+                           appending (list "-J" dir) into dirs
+                           finally return (append dirs (list buffer-to-eval)))))
+        (apply #'call-process jsonnet-command nil t nil args))
       (when (fboundp 'json-mode)
         (json-mode))
       (display-buffer (current-buffer)


### PR DESCRIPTION
## Description
Introduce the `jsonnet-lib-dirs` customizable variable to allow specifying the sequence of library directories in which Jsonnet should search for included files during evaluation, as one supplies to the _jsonnet_ command's `-J` or `--jpath` command-line flags.


## Motivation and Context
Without this change, it's not possible to evaluate Jsonnet files that import files that reside in a different directory. It's not possible to change the `jsonnet-command` variable to add one or more `-J` arguments, as Emacs interprets the first argument to `call-process` as a command name, not the start of a command invocation with some arguments present.


## How Has This Been Tested?
I tested this change interactively both without the new `jsonnet-lib-dirs` variable customized—leaving it with its default value of `nil`—and with it set to a singular _lib_ path, with another Jsonnet file sitting in the _./lib_ directory.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
- [x] My code follows the code style of this project (see https://github.com/bbatsov/emacs-lisp-style-guide).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
