### PR TITLE
Indent only two spaces in parens

### DIFF
--- a/jsonnet-mode.el
+++ b/jsonnet-mode.el
@@ -152,7 +152,7 @@ If not inside of a multiline string, return nil."
 ;; Experimental algorithm
 (defun jsonnet--indent-in-parens ()
   "Compute the indent of the current line, given it is inside parentheses."
-  (if (jsonnet--line-matches-regex-p "^\s*)") 0 4))
+  (if (jsonnet--line-matches-regex-p "^\s*)") 0 2))
 
 (defun jsonnet--indent-in-braces ()
   "Compute the indent of the current line, given it is inside braces."


### PR DESCRIPTION
## Description
Indent two spaces when inside parens, rather than four spaces.

## Motivation and Context
This matches the behavior of `jsonnet fmt`, reducing the number of changes made when running `jsonnet-reformat-buffer` from a save hook.

## How Has This Been Tested?
Open a paren, hit enter, observe the indentation :-)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project (see https://github.com/bbatsov/emacs-lisp-style-guide).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
