### PR TITLE
Keep the cursor in the same place when reformatting

### DIFF
--- a/jsonnet-mode.el
+++ b/jsonnet-mode.el
@@ -322,7 +322,12 @@ If not provided, current point is used."
 (defun jsonnet-reformat-buffer ()
   "Reformat entire buffer using the Jsonnet format utility."
   (interactive)
-  (call-process-region (point-min) (point-max) jsonnet-command t t nil "fmt" "-"))
+  (let ((current-window (selected-window))
+        (current-window-start (window-start))
+        (current-point (point)))
+    (call-process-region (point-min) (point-max) jsonnet-command t t nil "fmt" "-")
+    (set-window-start current-window current-window-start)
+    (goto-char current-point)))
 
 (define-key jsonnet-mode-map (kbd "C-c C-r") 'jsonnet-reformat-buffer)
 


### PR DESCRIPTION
When reformatting buffers, the cursor always ends up at the end of the buffer.

## Description
Save the position of the window and the point, then restore both after replacing the buffer contents.

## Motivation and Context
it's very annoying if you use this function in large files, because it always move the cursor to the end of the file.

## How Has This Been Tested?
I use it daily, and i have shared it with other members of my team.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (see https://github.com/bbatsov/emacs-lisp-style-guide).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
